### PR TITLE
feat: Adjust breakpoints and desktop header layout

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,18 +1,20 @@
 <script setup>
+
 import { ref } from 'vue'
 import Aside from '@/layouts/Aside.vue'
 import Header from './layouts/Header.vue'
 
-
 const isAsideOpen = ref(false)
 const toggleAside = () => isAsideOpen.value = !isAsideOpen.value
+
 </script>
 
 <template>
+
   <div class="flex flex-col md:flex-row min-h-screen">
     <Header :toggle-aside="toggleAside" class="md:hidden" />
     <Aside :is-aside-open="isAsideOpen" :toggle-aside="toggleAside" />
-    <Header :toggle-aside="toggleAside" class="hidden md:block" />
-
+    <Header :toggle-aside="toggleAside" class="hidden md:block w-full" />
   </div>
+
 </template>

--- a/src/layouts/Aside.vue
+++ b/src/layouts/Aside.vue
@@ -10,10 +10,10 @@ const props = defineProps({
 // Define as classes para a versão desktop, que empurra o conteúdo
 const asideDesktopClasses = computed(() => {
     return [
-        'h-dvh', 'bg-elight', 'transition-all', 'duration-300',
-        'hidden sm:block',
-        props.isAsideOpen ? 'sm:w-60' : 'sm:w-0',
-        props.isAsideOpen ? 'sm:overflow-auto' : 'sm:overflow-hidden'
+        'h-dvh', 'bg-elight', 'transition-all', 'duration-300', 'p-4',
+        'hidden md:block',
+        props.isAsideOpen ? 'md:w-60' : 'md:w-16',
+        props.isAsideOpen ? 'md:overflow-auto' : 'md:overflow-hidden'
     ]
 })
 </script>
@@ -21,8 +21,7 @@ const asideDesktopClasses = computed(() => {
 <template>
     <!-- Versão Mobile (com animação de deslizar) -->
     <Transition name="slide">
-        <aside v-if="isAsideOpen" class="sm:hidden h-dvh bg-elight w-full transition-transform duration-300 transform">
-            <!-- <MenuButton @toggle="toggleAside" /> -->
+        <aside v-if="isAsideOpen" class="md:hidden h-dvh bg-elight w-full transition-transform duration-300 transform">
         </aside>
     </Transition>
 

--- a/src/layouts/Header.vue
+++ b/src/layouts/Header.vue
@@ -13,8 +13,8 @@ const props = defineProps({
 
     <header class="p-4">
 
-        <nav class="flex justify-between items-center">
-            <MenuButton @toggle="toggleAside" class="sm:hidden" />
+        <nav class="flex justify-between items-center ">
+            <MenuButton @toggle="toggleAside" class="md:hidden" />
             <a href="#" class="font-[Crimson_Pro] text-gray-500 text-lg tracking-wider font-semibold">Matrisi</a>
             <Avatar />
         </nav>


### PR DESCRIPTION
- Refactor responsiveness breakpoints from 'sm' to 'md' across App.vue, Aside.vue, and Header.vue for consistency.
- Add 'w-full' to the desktop Header component in App.vue to ensure it occupies the full width.
- Refine the Aside component's desktop classes to control width and overflow based on the 'isAsideOpen' prop.
- Remove redundant 'sm:hidden' class from the mobile Aside to prevent conflicting styles.